### PR TITLE
Feat Vault secrets configuration and authentication

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,7 @@ type Config struct {
 	Email             Email             `mapstructure:"email"`
 	Authentication    Authentication    `mapstructure:"authentication"`
 	RabbitMQ          RabbitMQ          `mapstructure:"rabbitMQ"`
+	GoogleApiKey      GoogleAPI_KEY     `mapstructure:"google"`
 }
 
 // TODO: remove the print statement and add logger instead
@@ -91,6 +92,67 @@ func GetConfig() (*Config, error) {
 		logrus.Errorf("Unable to decode into struct, %v", err)
 		return config, err
 	}
+
+	logrus.Infof("Configuration file loaded: %+v", config) // Add this line to print the loaded configuration
+
+	var googleApiKey GoogleApiKey
+	err := ReadSecret("google", &googleApiKey)
+	if err != nil {
+		logrus.Errorf("Error reading secret from googleApiKey: %v", err)
+		return config, err
+	}
+
+	var primaryDBPassword PrimaryDBPassword
+	err = ReadSecret("db_password", &primaryDBPassword)
+	if err != nil {
+		logrus.Errorf("Error reading secret from primaryDBPassword: %v", err)
+		return config, err
+	}
+
+	var replicaOneDBPassword ReplicaOneDBPassword
+	err = ReadSecret("replica_db_password", &replicaOneDBPassword)
+	if err != nil {
+		logrus.Errorf("Error reading secret from replicaOneDBPassword: %v", err)
+		return config, err
+	}
+
+	var jWTSecret JWTSecret
+	err = ReadSecret("JWT", &jWTSecret)
+	if err != nil {
+		logrus.Errorf("Error reading secret from jWTSecret: %v", err)
+		return config, err
+	}
+
+	var opensearchPassword OpensearchPassword
+	err = ReadSecret("os_password", &opensearchPassword)
+	if err != nil {
+		logrus.Errorf("Error reading secret from opensearchPassword: %v", err)
+		return config, err
+	}
+
+	var emailPassword EmailPassword
+	err = ReadSecret("smtp_password", &emailPassword)
+	if err != nil {
+		logrus.Errorf("Error reading secret from emailPassword: %v", err)
+		return config, err
+	}
+
+	var rabbitMQPassword RabbitMQPassword
+	err = ReadSecret("rabbitPassword", &rabbitMQPassword)
+	if err != nil {
+		logrus.Errorf("Error reading secret from rabbitMQPassword: %v", err)
+		return config, err
+	}
+
+	config.JWT.SecretKey = jWTSecret.Key
+	config.Postgresql.PrimaryDB.DBPassword = primaryDBPassword.Key
+	config.Postgresql.Replica1.DBPassword = replicaOneDBPassword.Key
+	config.Opensearch.Password = opensearchPassword.Key
+	config.GoogleApiKey.API_KEY = googleApiKey.Key
+	config.RabbitMQ.Password = rabbitMQPassword.Key
+	config.Email.SMTPPassword = emailPassword.Key
+
+	logrus.Infof("config vlaue %v", config)
 
 	return config, nil
 }

--- a/config/vault.go
+++ b/config/vault.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"context"
+	"os"
+	"time"
+
+	"github.com/hashicorp/vault-client-go"
+	"github.com/hashicorp/vault-client-go/schema"
+	"github.com/mitchellh/mapstructure"
+)
+
+type GoogleAPI_KEY struct {
+	API_KEY string `mapstructure:"API_KEY"`
+}
+
+type GoogleApiKey struct {
+	Key string `mapstructure:"API_KEY"`
+}
+
+type PrimaryDBPassword struct {
+	Key string `mapstructure:"db_password"`
+}
+
+type ReplicaOneDBPassword struct {
+	Key string `mapstructure:"replica_db_password"`
+}
+
+type EmailPassword struct {
+	Key string `mapstructure:"smtp_password"`
+}
+
+type JWTSecret struct {
+	Key string `mapstructure:"JWT"`
+}
+
+type OpensearchPassword struct {
+	Key string `mapstructure:"os_password"`
+}
+
+type RabbitMQPassword struct {
+	Key string `mapstructure:"rabbitPassword"`
+}
+
+func ReadSecret[T any](secretName string, result *T) error {
+	ctx := context.Background()
+
+	client, err := vault.New(
+		vault.WithAddress("http://vault:8200"),
+		vault.WithRequestTimeout(30*time.Second),
+	)
+	if err != nil {
+		logrus.Errorf("Error reading config file, %v", err)
+		return err
+	}
+
+	// authenticate with a root approle
+	resp, err := client.Auth.AppRoleLogin(
+		ctx,
+		schema.AppRoleLoginRequest{
+			RoleId:   os.Getenv("APPROLE_ROLE_ID"),
+			SecretId: os.Getenv("APPROLE_SECRET_ID"),
+		},
+		vault.WithMountPath("approle"),
+	)
+
+	if err != nil {
+		logrus.Errorf("error geting os env to Vault: %v", err)
+		return err
+	}
+
+	if err := client.SetToken(resp.Auth.ClientToken); err != nil {
+		logrus.Errorf("error setting Vault token: %v", err)
+		return err
+	}
+
+	secret, err := client.Secrets.KvV2Read(ctx, secretName, vault.WithMountPath("secret"))
+	if err != nil {
+		logrus.Errorf("error reading secret from Vault: %w", err)
+		return err
+	}
+
+	if err := mapstructure.Decode(secret.Data.Data, result); err != nil {
+		logrus.Errorf("error decoding secret data: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,6 +192,18 @@ services:
       - "50052:50052"
     working_dir: /go/src/app
     command: go run microservices/the_monkeys_blog/main.go
+  
+  vault:
+    container_name: vault
+    image: hashicorp/vault:latest
+    networks:
+      - monkeys-network
+    ports:
+      - 8200:8200
+    environment:
+      - VAULT_ADDR=http://0.0.0.0:8200
+      - VAULT_DEV_ROOT_TOKEN_ID=myroot
+
 
 networks:
   monkeys-network:


### PR DESCRIPTION
## Context

Related to the [issue](https://github.com/the-monkeys/the_monkeys_engine/issues/56), a vault secret service must be brought to the system. 

## Solution 

I chose the [HasiCorp Vault](https://developer.hashicorp.com/vault) because it is accessible and well-known on the market. 

To use it, we need to generate the role ID and the secret ID, pass them as env to the microservice you want to log into the Vault and get the secrets. 

This PR contains the code to authenticate with this approach and fill the config variable with the respective secrets. 

